### PR TITLE
Fix Cloud.gov Build Errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,3 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
-
-# Ruby v3 and above no longer ship with webrick
-gem "webrick", "~> 1.8"

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-ruby '~> 3.2'
+ruby '~> 3.2.0'
 
 # Hello! This is where you manage which Jekyll version is used to run.
 # When you want to use a different version, change it below, save the

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
   x64-mingw32
   x86_64-darwin-18
 
@@ -89,7 +90,7 @@ DEPENDENCIES
   kramdown-parser-gfm
   minima (~> 2.0)
   tzinfo-data
-  webrick (~> 1.8)
+  webrick
 
 RUBY VERSION
    ruby 3.2.2p53


### PR DESCRIPTION
## Description

This PR fixes some build issues on Cloud.gov using the latest version of `master`:
1. Remove specific version of webrick to resolve this error:
```
2023-08-07 15:04:47 INFO [setup-bundler [!] There was an error parsing `Gemfile`: You cannot specify the same gem twice with different version requirements.
2023-08-07 15:04:47 INFO [setup-bundler] You specified: webrick (>= 0) and webrick (~> 1.8). Bundler cannot continue.
2023-08-07 15:04:47 INFO [setup-bundler] #  from /tmp/work/site_repo/Gemfile:36
```

2. Added patch version of Ruby to Gemfile to resolve this error:
```
2023-08-07 15:04:45 INFO [setup-bundler] Unknown ruby interpreter version (do not know how to handle): ~>3.2.
```
## Testing

Tested local bundle install