### PR TITLE
Begin recruiting cycle for 2024 cohort

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,4 +1,16 @@
 {% include components/banner.html %}
+{% if page.url == '/' %}
+<div class="usa-alert usa-alert--info">
+  <a class="application-link" href="{{ site.baseurl }}/apply">
+    <div class="usa-alert__body">
+        <h4 class="usa-alert__heading">Coming Soon - Recruiting for the 2024 Cohort!</h4>
+        <p class="usa-alert__text">
+            The application period for the Emerging Technology Fellowship will open in the next few weeks! Check back with us soon.
+        </p>
+    </div>
+  </a>
+</div>
+{% endif %}
 <header class="usa-header site-header">
   <div class="usa-navbar site-header-navbar">
     <div class="grid-row">

--- a/_pages/apply.md
+++ b/_pages/apply.md
@@ -13,24 +13,21 @@ seo_excerpt:
         <div class="section-breadcrumb">Apply to xD</div>
         <h1>Emerging Technology Fellowship</h1>
         <p>
-          We’re looking for purpose-driven technologists and innovators to join 
-          this unique fellowship experience with xD. <strong>The Emerging 
-          Technology Fellowship (ETF)</strong> recruits the best and brightest 
-          technologists with expertise in emerging data technology trends to 
+          We’re looking for purpose-driven technologists and innovators to join
+          this unique fellowship experience with xD. <strong>The Emerging
+          Technology Fellowship (ETF)</strong> recruits the best and brightest
+          technologists with expertise in emerging data technology trends to
           build a better government for everyone.
         </p>
         <div class="usa-alert usa-alert--info">
             <div class="usa-alert__body">
-                <h4 class="usa-alert__heading">Application Period Closed</h4>
+                <h4 class="usa-alert__heading">Coming Soon - Recruiting for the 2024 Cohort!</h4>
                 <p class="usa-alert__text">
-                    The application period for the Emerging Technology 
-                    Fellowship has closed. We plan on recruiting again in Fall
-                    of 2023. Thank you to all who applied and we’ll be in touch
-                    soon!
+                    The application period for the Emerging Technology Fellowship will open in the next few weeks! Check back with us soon.
                 </p>
             </div>
         </div>
-        {% for position in site.positions %} 
+        {% for position in site.positions %}
             {% include components/position.html position=position %}
         {% endfor %}
         <!--<div class="grid-row">
@@ -56,28 +53,28 @@ seo_excerpt:
     </div>
     <div class="grid-row">
       <p>
-        We’re looking for teammates who are motivated by curiosity and have a 
-        desire to make lasting positive impact. Emerging Technology Fellows 
-        bring an entrepreneurial spirit and expertise in emerging technologies 
-        to solve some of the most pressing federal data challenges of the 21st 
-        century. If you love a challenge, have demonstrated leadership in your 
-        career, and you’re looking to apply your talents towards high-impact 
+        We’re looking for teammates who are motivated by curiosity and have a
+        desire to make lasting positive impact. Emerging Technology Fellows
+        bring an entrepreneurial spirit and expertise in emerging technologies
+        to solve some of the most pressing federal data challenges of the 21st
+        century. If you love a challenge, have demonstrated leadership in your
+        career, and you’re looking to apply your talents towards high-impact
         projects, you may be a great fit for the Emerging Technology Fellowship!
       </p>
     </div>
-    {% 
-      include components/praise.html 
-      content="Working at xD gives an opportunity to work on interesting data problems with interesting people from within one of the most quietly important agencies in the U.S. There is no shortage of issues in government that can be improved with better collection, management, and use of data, and xD gives exposure to a bunch of them." 
-      author="Aidan Feldman" 
-      author_title="2017 Fellow. Technologist, Dancer, Adjunct Assistant Professor of Public Service NYU|Wagner" 
-      image_path="/assets/img/praise/feldman.jpeg" 
+    {%
+      include components/praise.html
+      content="Working at xD gives an opportunity to work on interesting data problems with interesting people from within one of the most quietly important agencies in the U.S. There is no shortage of issues in government that can be improved with better collection, management, and use of data, and xD gives exposure to a bunch of them."
+      author="Aidan Feldman"
+      author_title="2017 Fellow. Technologist, Dancer, Adjunct Assistant Professor of Public Service NYU|Wagner"
+      image_path="/assets/img/praise/feldman.jpeg"
     %}
     <div class="grid-row">
       <div class="section-breadcrumb">What Specialized Experience Are We Looking For?</div>
     </div>
     <div class="grid-row">
       <p>
-        Qualified candidates demonstrate experience exercising a high degree of 
+        Qualified candidates demonstrate experience exercising a high degree of
         creativity and seasoned judgment and apply agile, lean, open-source, and
         human-centered design principles to develop new concepts, products, and
         services in response to challenges faced by customers and stakeholders;
@@ -89,8 +86,8 @@ seo_excerpt:
         <div class="usa-alert__body">
           <p class="usa-alert__text">
             <strong>
-              If you have the specialized experience above, please ensure it is 
-              reflected in your resume as it will be used to determine your 
+              If you have the specialized experience above, please ensure it is
+              reflected in your resume as it will be used to determine your
               qualifications.
             </strong>
           </p>

--- a/_positions/etf-geo-15.md
+++ b/_positions/etf-geo-15.md
@@ -6,7 +6,7 @@ location: TBD Upon Selection
 pay_range_min: $112,890
 pay_range_max: $146,757
 subject_line: Emerging Technology Fellowship Application
-subtitle: 2023 Cohort
+subtitle: 2024 Cohort
 travel: Minimal
 ---
 
@@ -31,7 +31,5 @@ travel: Minimal
 </div>
 
 <p class="margin-bottom-0">
-  All U.S. citizens welcome to apply. The application period for the 2022 cohort
-  is now closed.
+  All U.S. citizens welcome to apply. The application period for the 2024 cohort will open soon!
 </p>
-

--- a/assets/css/_pages/_home.scss
+++ b/assets/css/_pages/_home.scss
@@ -18,7 +18,7 @@
     padding-top: 2rem;
 
     @media only screen and(min-width: $tablet-size) {
-      padding-top: 6rem;      
+      padding-top: 6rem;
     }
 
     .gray-box {
@@ -53,17 +53,17 @@
     width: 100%;
 
     @media only screen and(min-width: $desktop-size) {
-      padding: 2rem;      
+      padding: 2rem;
     }
 
     p {
 
       @media only screen and(min-width: $tablet-size) {
-        font-size: 1.1rem;        
+        font-size: 1.1rem;
       }
 
       @media only screen and(min-width: $desktop-size) {
-        font-size: 1.2rem;        
+        font-size: 1.2rem;
       }
     }
   }
@@ -73,11 +73,11 @@
     padding: 6rem 0;
 
     @media only screen and(min-width: $tablet-size) {
-      padding: 6rem 0;        
+      padding: 6rem 0;
     }
 
     @media only screen and(min-width: $desktop-size) {
-      padding: 2rem;        
+      padding: 2rem;
     }
   }
 }
@@ -157,7 +157,7 @@
 .page-home {
 
   main {
-    
+
     &.main-content {
       padding-top: 0;
     }
@@ -172,5 +172,13 @@
         padding-top: 6rem;
       }
     }
+  }
+}
+
+.application-link {
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
   }
 }


### PR DESCRIPTION
## Description
Copy updates and blue application banner at top of homepage for upcoming 2024 ETF recruiting cycle.

UX for homepage banner: clicking anywhere on the banner will take user to `/apply` page. Hovering mouse over the banner causes underline of text to appear.

## Testing
Local build and responsive design inspection

## Screenshots
Updated apply page copy:
<img width="1670" alt="Screenshot 2023-10-13 at 8 45 38 AM" src="https://github.com/XDgov/xd.gov/assets/146035592/f52833e7-3e66-435a-9492-bc6d6e0f868e">

Homepage apply banner - desktop:
<img width="1172" alt="Screenshot 2023-10-13 at 9 18 23 AM" src="https://github.com/XDgov/xd.gov/assets/146035592/2afcc444-1756-481b-b2e7-fdc5a9c19700">

Homepage apply banner - smartphone:
<img width="429" alt="Screenshot 2023-10-13 at 9 33 07 AM" src="https://github.com/XDgov/xd.gov/assets/146035592/dd3998e9-37f8-4e01-8ca4-77793d2aa266">
