### PR TITLE
Fix : Add visually-hidden span for more descriptive link text

### DIFF
--- a/_includes/components/featured-news-item.html
+++ b/_includes/components/featured-news-item.html
@@ -5,5 +5,5 @@
   <a href="{{ site.baseurl }}{{ news.permalink }}">
     <h2>{{ news.title }}</h2>
   </a>
-  <a class="square-link" href="{{ site.baseurl }}{{ news.permalink }}">Learn More</a>
+  <a class="square-link" href="{{ site.baseurl }}{{ news.permalink }}">Learn More<span class="visually-hidden"> about {{ news.title }}</span></a>
 </div>

--- a/_includes/components/navigation.html
+++ b/_includes/components/navigation.html
@@ -57,7 +57,7 @@
       </li>
       {% endfor %}
       <li>
-        <a href="https://public.govdelivery.com/accounts/USCENSUS/signup/34927" class="usa-button usa-button-black" target="_blank">Subscribe</a>
+        <a href="https://public.govdelivery.com/accounts/USCENSUS/signup/34927" class="usa-button usa-button-black" target="_blank">Subscribe<span class="visually-hidden"> to the xD mailing list</span></a>
       </li>
     </ul>
     {% endif %}

--- a/_includes/components/news-item.html
+++ b/_includes/components/news-item.html
@@ -8,6 +8,6 @@
     <h3>
       <a href="{{ site.baseurl }}{{ news.permalink }}">{{ news.title }}</a>
     </h3>
-    <a class="square-link" href="{{ site.baseurl }}{{ news.permalink }}">Learn More</a>
+    <a class="square-link" href="{{ site.baseurl }}{{ news.permalink }}">Learn More<span class="visually-hidden"> about {{ news.title }}</span></a>
   </div>
 </div>

--- a/_includes/components/project-card.html
+++ b/_includes/components/project-card.html
@@ -8,7 +8,7 @@
         <a href="{{ site.baseurl }}{{ project.permalink }}">{{ project.title }}</a>
       </h3>
       <p>{{ project.subtitle }}</p>
-      <a class="square-link" href="{{ site.baseurl }}{{ project.permalink }}">Learn More</a>
+      <a class="square-link" href="{{ site.baseurl }}{{ project.permalink }}">Learn More<span class="visually-hidden"> about {{ project.title }}</span></a>
     </div>
   </div>
 </div>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -34,7 +34,7 @@
               Fellowship by signing up for updates.
             </p>
             <p>
-              <a href="https://public.govdelivery.com/accounts/USCENSUS/signup/34927" target="_blank" class="usa-button usa-button-white">Subscribe</a>
+              <a href="https://public.govdelivery.com/accounts/USCENSUS/signup/34927" target="_blank" class="usa-button usa-button-white">Subscribe<span class="visually-hidden"> to the xD mailing list</span></a>
             </p>
           </div>
         </div>

--- a/assets/css/_includes/_typography.scss
+++ b/assets/css/_includes/_typography.scss
@@ -1,3 +1,13 @@
 .font-size-sm {
   font-size: 0.9rem !important;
 }
+
+.visually-hidden {
+  clip-path: inset(100%);
+  clip: rect(1px, 1px, 1px, 1px);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}

--- a/collections/_news/kate-mccall-kiley-named-2019-mit-fellow.md
+++ b/collections/_news/kate-mccall-kiley-named-2019-mit-fellow.md
@@ -15,5 +15,5 @@ image_accessibility: Kate McCall-Kiley
 </p>
 
 <p class="news-cta">
-  <a class="square-link" href="https://www.media.mit.edu/groups/directors-fellows-program/overview/" target="_blank">Learn More</a>
+  <a class="square-link" href="https://www.media.mit.edu/groups/directors-fellows-program/overview/" target="_blank">Learn More<span class="visually-hidden"> about the Director's Fellows Program</span></a>
 </p>

--- a/collections/_pages/home.md
+++ b/collections/_pages/home.md
@@ -16,7 +16,7 @@ title: Home
       xD is an emerging technologies group that’s advancing the delivery of 
       data-driven services through new and transformative technologies.
     </h2>
-    <a class="square-link" href="{{ site.baseurl }}/about">Learn More</a>
+    <a class="square-link" href="{{ site.baseurl }}/about">Learn More<span class="visually-hidden"> about xD</span></a>
   </div>
 </section>
 
@@ -29,7 +29,7 @@ title: Home
         {% include components/project-card.html project=project %}
       {% endfor %}
     </div>
-    <a class="usa-button usa-button-black" href="{{ site.baseurl }}/projects">View All</a>
+    <a class="usa-button usa-button-black" href="{{ site.baseurl }}/projects">View All<span class="visually-hidden"> xD projects</span></a>
   </div>
 </section>
 


### PR DESCRIPTION
## Description
Links should have descriptive text. This isn't just for Accessibility, but for SEO. This update adds a new class and implements it into the shared components wherever "learn more", "apply now", or "subscribe" link copy applies.

Resolves: #38 

## Changes
- Add `visually hidden` span class and style, update components, collections references where applicable
- Add `visually-hidden` span to subscribe links
