### PR TITLE
Learn more and text clipping issue

### DIFF
--- a/assets/css/_pages/_home.scss
+++ b/assets/css/_pages/_home.scss
@@ -49,11 +49,12 @@
   .hero-left-content {
     margin: 0 auto;
     max-width: 600px;
-    padding: 1rem 2rem 1rem 1rem;
+    padding: 1rem 2rem calc(1rem + 30px) 1rem;
     width: 100%;
 
     @media only screen and(min-width: $desktop-size) {
       padding: 2rem;
+      padding-bottom: calc(2rem + 30px);
     }
 
     p {


### PR DESCRIPTION

## Description
A clipping issue could occur behind the gray box on home layout when left-side column content was longer. This corrects that issue.
Resolves: #24

## Changes
Update `padding-bottom` to prevent clipping on smaller layouts or when text is longer in left column.

### Before
![image](https://github.com/XDgov/xd.gov/assets/1375526/3b43697a-ca69-4ce4-949a-cd9e28071018)

### After
