### PR TITLE
Address external link vulnerability

### DIFF
--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -16,7 +16,7 @@ layout: default
                   {% unless forloop.index == 1 %}
                    /
                   {% endunless %}
-                  <a href="{{ entity.url }}" target="_blank" target="_blank" rel="noopener noreferrer">{{ entity.name }}</a>
+                  <a href="{{ entity.url }}" target="_blank" rel="noopener noreferrer">{{ entity.name }}</a>
                 {% endfor %}
               </td>
             </tr>

--- a/_layouts/project.html
+++ b/_layouts/project.html
@@ -16,7 +16,7 @@ layout: default
                   {% unless forloop.index == 1 %}
                    /
                   {% endunless %}
-                  <a href="{{ entity.url }}" target="_blank">{{ entity.name }}</a>
+                  <a href="{{ entity.url }}" target="_blank" target="_blank" rel="noopener noreferrer">{{ entity.name }}</a>
                 {% endfor %}
               </td>
             </tr>


### PR DESCRIPTION
## Description
Resolves #57 by preventing the target page from accessing the DOM of the origin page with the attribute `rel="noopener noreferrer"`.

## Testing
N/A