### PR TITLE
Add robots.txt file

### DIFF
--- a/.github/lighthouse/lighthouserc.js
+++ b/.github/lighthouse/lighthouserc.js
@@ -1,5 +1,3 @@
-// note that some settings in the lighthouserc.js are permanent since they apply to the deployed site but not the dev instance. For example, the gem 'jekyll-sitemap' creates a robots.txt file for SEO when the site is deployed, but the local build does not have this file.
-
 module.exports = {
   "ci": {
     "collect": {

--- a/.github/lighthouse/lighthouserc.js
+++ b/.github/lighthouse/lighthouserc.js
@@ -1,4 +1,6 @@
-{
+// note that some settings in the lighthouserc.js are permanent since they apply to the deployed site but not the dev instance. For example, the gem 'jekyll-sitemap' creates a robots.txt file for SEO when the site is deployed, but the local build does not have this file.
+
+module.exports = {
   "ci": {
     "collect": {
       "staticDistDir": "./_site"

--- a/.github/lighthouse/lighthouserc.json
+++ b/.github/lighthouse/lighthouserc.json
@@ -1,5 +1,9 @@
 {
   "ci": {
+    "collect": {
+      "startServerCommand": "bundle exec jekyll serve",
+      "url": ["http://localhost:4000/"]
+    },
     "upload": {
       "target": "temporary-public-storage"
     },

--- a/.github/lighthouse/lighthouserc.json
+++ b/.github/lighthouse/lighthouserc.json
@@ -15,7 +15,6 @@
         "image-size-responsive": "off",
         "link-text": "off",
         "maskable-icon": "off",
-        "robots-txt": "off",
         "service-worker": "off",
         "splash-screen": "off",
         "themed-omnibox": "off",

--- a/.github/lighthouse/lighthouserc.json
+++ b/.github/lighthouse/lighthouserc.json
@@ -1,8 +1,7 @@
 {
   "ci": {
     "collect": {
-      "startServerCommand": "bundle exec jekyll serve",
-      "url": ["http://localhost:4000/"]
+      "staticDistDir": "./_site"
     },
     "upload": {
       "target": "temporary-public-storage"

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -19,9 +19,10 @@ jobs:
       - run: |
           bundle install
           bundle exec jekyll build
+          bundle exec jekyll serve
       - name: run Lighthouse CI
         run: |
           npm install -g @lhci/cli@0.12.x
-          lhci autorun --config=./.github/lighthouse/lighthouserc.json
+          lhci autorun --config=./.github/lighthouse/lighthouserc.js
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -19,7 +19,6 @@ jobs:
       - run: |
           bundle install
           bundle exec jekyll build
-          bundle exec jekyll serve
       - name: run Lighthouse CI
         run: |
           npm install -g @lhci/cli@0.12.x

--- a/_config.yml
+++ b/_config.yml
@@ -33,7 +33,7 @@ collections:
     output: true
     permalink: /blog/:permalink/
   import:
-    output: true  
+    output: true
 collections_dir: collections
 
 defaults:

--- a/robots.txt
+++ b/robots.txt
@@ -1,5 +1,0 @@
-User-Agent: *
-Allow: /
-
-Host: https://xd.gov
-Sitemap: https://xd.gov/sitemap.xml

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,5 @@
+User-Agent: *
+Allow: /
+
+Host: https://xd.gov
+Sitemap: https://xd.gov/sitemap.xml


### PR DESCRIPTION
## Description
Adds a valid robots.txt file to the repository to improve the site's SEO score. The gem `jekyll-sitemap` generates a robots.txt file at build time, but it appears to be incorrectly formatted and the Jekyll team [doesn't have the bandwidth to fix it](https://github.com/jekyll/jekyll-sitemap/issues/292#issuecomment-1146802072).

Resolves https://github.com/XDgov/us-pets-lab/issues/11. 

## Testing
N/A