### PR TITLE
Add Interview guide

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
+  arm64-darwin-23
   x64-mingw-ucrt
   x64-mingw32
   x86_64-darwin-18

--- a/collections/_pages/interview-guide.md
+++ b/collections/_pages/interview-guide.md
@@ -1,0 +1,89 @@
+---
+permalink: /interview-guide/
+image: /assets/img/pages/apply/apply-og.png
+layout: page
+title: Interview Guide
+---
+
+<section class="intro">
+    <div class="grid-container">
+        <h1>Emerging Tech Fellowship Interview Guide</h1>
+        <p>
+          Thank you for considering a role at xD and the Emerging Tech Fellowship! We’d like everyone to put their best foot forward and, in that spirit, have created this guide to help you shine during your interview.
+        </p>
+        <div class="grid-row">
+            <div class="grid-col-12">
+                <h3>Interview Checklist</h3>
+                <p>
+                    As part of the xD interview process, you will be asked to participate in a technical interview and a behavioral interview. During your technical interview, you should be able to demonstrate that your experience aligns with the role you’re applying for by providing clear examples of your work.
+                </p>
+                <p>
+                    Here are a few things you can do to prepare for your interviews:
+                </p>
+                <ul class="usa-icon-list maxw-full">
+                    <li class="usa-icon-list__item">
+                        <div class="usa-icon-list__icon">
+                            <svg class="usa-icon" aria-hidden="true" focusable="false" role="img"><use xlink:href="/assets/img/sprite.svg#check_box_outline_blank"></use></svg>
+                        </div>
+                        <div class="usa-icon-list__content">
+                            All of our interviews are conducted over video calls with <a class="usa-link" href="https://www.microsoft.com/en-us/microsoft-teams/group-chat-software" target="_blank">Microsoft Teams</a>. We recommend downloading the Microsoft Teams application or testing the in-browser version of Teams to ensure everything is working prior to the interview. This helps everyone save time!
+                        </div>
+                    </li>
+                    <li class="usa-icon-list__item">
+                        <div class="usa-icon-list__icon">
+                            <svg class="usa-icon" aria-hidden="true" focusable="false" role="img"><use xlink:href="/assets/img/sprite.svg#check_box_outline_blank"></use></svg>
+                        </div>
+                        <div class="usa-icon-list__content">
+                            In your technical interview, we are most excited to hear about independent work, such as self-directed research/academic or commercial projects, theses or papers, competition submissions, and other independent project work. Most helpful are projects more expansive than a course homework assignment (unless it is something you are especially proud of), that have been used to solve a real-world problem, and that have a strong creative component or involve a clever, novel solution.
+                        </div>
+                    </li>
+                    <li class="usa-icon-list__item">
+                        <div class="usa-icon-list__icon">
+                            <svg class="usa-icon" aria-hidden="true" focusable="false" role="img"><use xlink:href="/assets/img/sprite.svg#check_box_outline_blank"></use></svg>
+                        </div>
+                        <div class="usa-icon-list__content">
+                            In your behavioral interview, we are most excited to hear more about you! This interview requires no preparation in advance and is a space for us to learn how we’d work together should you join our team.
+                        </div>
+                    </li>
+                    <li class="usa-icon-list__item">
+                        <div class="usa-icon-list__icon">
+                            <svg class="usa-icon" aria-hidden="true" focusable="false" role="img"><use xlink:href="/assets/img/sprite.svg#check_box_outline_blank"></use></svg>
+                        </div>
+                        <div class="usa-icon-list__content">
+                            We are giving all candidates the option to share your relevant BitBucket, GitHub, GitLab, or a comparable version control platform account with us in advance. This helps us understand the type of open-source work you’ve produced in the past, if any.
+                        </div>
+                    </li>
+                </ul>
+                <h3>Frequently Asked Questions</h3>
+                <h4>What is xD?</h4>
+                <p>
+                    xD is an emerging technologies group that is demonstrating the art of the possible through new and transformative data technologies. Serving as a technical consultancy in the Deputy Director’s Office at the U.S. Census Bureau, xD collaborates with program areas at Census and with other federal agencies, national statistical offices, international organizations, academia, and NGOs to bring technologists and statisticians together to enhance the ways data is used, understood, accessed, and shared.
+                </p>
+                <h4>What does xD stand for?</h4>
+                <p>
+                    At one point, xD stood for “experimental data.” We dropped that portion of the name some time ago to keep things simple and <span class="text-italic">mysterious</span>.
+                </p>
+                <h4>What's the story behind xD?</h4>
+                <p>
+                    The Census Bureau has long been technologically forward-thinking, from creating the first punch cards and electronic tabulators to being the first civilian agency to install and use the UNIVAC 1 mainframe computer. Founded in 2017 by Presidential Innovation Fellows, xD continues in this tradition by exploring partnership with industry leaders and continuing to drive innovation at the Census Bureau. Working with other federal agencies and academia to bring artificial intelligence, data science, and other cutting-edge approaches to the work of the U.S. Census Bureau, xD has been focused on two project portfolios – Combating Bias in AI and Deploying Privacy Enhancing Technologies (PETs) – and will continue to explore further innovation in the coming years.
+                </p>
+                <h4>How are projects funded or selected at xD?</h4>
+                <p>
+                    Funding for xD consists of working capital, GSA 10x grants, and program-area funding to support the work of Emerging Technology Fellows (ETFs). ETFs are hired on term-based appointments as federal employees, which range from one to four years in length, and include full federal benefits. With salaries ranging from the GS-13 to GS-15 levels, fellows serve as senior technical experts on their assigned projects. Fellows report to and are managed by xD staff in partnership with division leadership throughout the Bureau. While ETFs may be hired to support a particular project, the fellowship experience is meant to offer insights into the broader work of the Census Bureau as well as other federal agencies, and to allow for opportunities to explore a variety of paths.
+                </p>
+                <h4>What’s it like being an Emerging Tech Fellow?</h4>
+                <p>
+                    In addition to project work, each fellow will have the opportunity to pitch new projects for funding, to meet practitioners across government working in data science and AI, and to become more fully involved in the civic tech space. With that in mind, ideal candidates for the Emerging Technology Fellowship have an entrepreneurial mindset, are open to trying new things (and being wrong!) and finding new opportunities to grow. Fellows are independent yet collaborative and will work with a variety of technical and non-technical stakeholders, often teaching and/or guiding others along the way. ETFs have an ability to solve real-world problems, and excel at implementing new techniques from machine learning, artificial intelligence, and data science research into their work at the Census Bureau.
+                </p>
+                <h4>Where are you based? Do you allow remote work?</h4>
+                <p>
+                    Yes. xD is based at the U.S. Census Bureau in Suitland, MD, but most of our team works remotely. Our team works synchronously during normal government business hours (9-5 EST).
+                </p>
+                <h4>Why should I consider joining xD?</h4>
+                <p>
+                    As an Emerging Tech Fellow at xD, you will have the opportunity to: do fast-paced, truly innovative work in a mission-driven startup in government that values technical excellence, creativity, and diversity; interact with top decision-makers across the federal government; work in partnership with top universities and major tech companies; and do meaningful, high-impact work that could improve the lives of millions of Americans.
+                </p>
+            </div>
+        </div>
+    </div>
+</section>

--- a/collections/_pages/interview-guide.md
+++ b/collections/_pages/interview-guide.md
@@ -23,7 +23,7 @@ title: Interview Guide
                 <ul class="usa-icon-list maxw-full">
                     <li class="usa-icon-list__item">
                         <div class="usa-icon-list__icon">
-                            <svg class="usa-icon" aria-hidden="true" focusable="false" role="img"><use xlink:href="/assets/img/sprite.svg#check_box_outline_blank"></use></svg>
+                            <svg class="usa-icon" aria-hidden="true" focusable="false" role="img"><use xlink:href="{{ site.baseurl }}/assets/img/sprite.svg#check_box_outline_blank"></use></svg>
                         </div>
                         <div class="usa-icon-list__content">
                             All of our interviews are conducted over video calls with <a class="usa-link" href="https://www.microsoft.com/en-us/microsoft-teams/group-chat-software" target="_blank">Microsoft Teams</a>. We recommend downloading the Microsoft Teams application or testing the in-browser version of Teams to ensure everything is working prior to the interview. This helps everyone save time!
@@ -31,7 +31,7 @@ title: Interview Guide
                     </li>
                     <li class="usa-icon-list__item">
                         <div class="usa-icon-list__icon">
-                            <svg class="usa-icon" aria-hidden="true" focusable="false" role="img"><use xlink:href="/assets/img/sprite.svg#check_box_outline_blank"></use></svg>
+                            <svg class="usa-icon" aria-hidden="true" focusable="false" role="img"><use xlink:href="{{ site.baseurl }}/assets/img/sprite.svg#check_box_outline_blank"></use></svg>
                         </div>
                         <div class="usa-icon-list__content">
                             In your technical interview, we are most excited to hear about independent work, such as self-directed research/academic or commercial projects, theses or papers, competition submissions, and other independent project work. Most helpful are projects more expansive than a course homework assignment (unless it is something you are especially proud of), that have been used to solve a real-world problem, and that have a strong creative component or involve a clever, novel solution.
@@ -39,7 +39,7 @@ title: Interview Guide
                     </li>
                     <li class="usa-icon-list__item">
                         <div class="usa-icon-list__icon">
-                            <svg class="usa-icon" aria-hidden="true" focusable="false" role="img"><use xlink:href="/assets/img/sprite.svg#check_box_outline_blank"></use></svg>
+                            <svg class="usa-icon" aria-hidden="true" focusable="false" role="img"><use xlink:href="{{ site.baseurl }}/assets/img/sprite.svg#check_box_outline_blank"></use></svg>
                         </div>
                         <div class="usa-icon-list__content">
                             In your behavioral interview, we are most excited to hear more about you! This interview requires no preparation in advance and is a space for us to learn how we’d work together should you join our team.
@@ -47,7 +47,7 @@ title: Interview Guide
                     </li>
                     <li class="usa-icon-list__item">
                         <div class="usa-icon-list__icon">
-                            <svg class="usa-icon" aria-hidden="true" focusable="false" role="img"><use xlink:href="/assets/img/sprite.svg#check_box_outline_blank"></use></svg>
+                            <svg class="usa-icon" aria-hidden="true" focusable="false" role="img"><use xlink:href="{{ site.baseurl }}/assets/img/sprite.svg#check_box_outline_blank"></use></svg>
                         </div>
                         <div class="usa-icon-list__content">
                             We are giving all candidates the option to share your relevant BitBucket, GitHub, GitLab, or a comparable version control platform account with us in advance. This helps us understand the type of open-source work you’ve produced in the past, if any.

--- a/robots.txt
+++ b/robots.txt
@@ -1,5 +1,6 @@
 User-Agent: *
 Allow: /
+Disallow: /interview-guide$
 
 Host: https://xd.gov
 Sitemap: https://xd.gov/sitemap.xml


### PR DESCRIPTION
## Description
Adds an interview guide for ETF candidates. This page is not linked in the rest of the website and is ignored in `robots.txt`.

## Testing
N/A