### PR TITLE
Revert GSA DAP to script instead of preconnect link

### DIFF
--- a/.github/lighthouse/lighthouserc.js
+++ b/.github/lighthouse/lighthouserc.js
@@ -25,6 +25,7 @@ module.exports = {
         "unused-css-rules": "off",
         "unused-javascript": "off",
         "uses-optimized-images": "off",
+        "uses-rel-preconnect": "off", // can't use with GSA DAP script
         "uses-responsive-images": "off",
         "uses-text-compression": "off"
       }

--- a/.github/lighthouse/lighthouserc.js
+++ b/.github/lighthouse/lighthouserc.js
@@ -18,6 +18,7 @@ module.exports = {
         "image-size-responsive": "off",
         "link-text": "off",
         "maskable-icon": "off",
+        "offscreen-images": "off",
         "service-worker": "off",
         "splash-screen": "off",
         "themed-omnibox": "off",

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -99,5 +99,5 @@
 
     gtag('config', 'G-3P989H6XN2');
   </script>
-  <script id="_fed_an_ua_tag" src=https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=DOC&amp;subagency=CEN></script>
+  <script async type="text/javascript" id="_fed_an_ua_tag" src=https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=DOC&amp;subagency=CEN></script>
 </head>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -99,5 +99,5 @@
 
     gtag('config', 'G-3P989H6XN2');
   </script>
-  <link rel="preconnect" href="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=DOC&amp;subagency=CEN" />
+  <script id="_fed_an_ua_tag" src=https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=DOC&amp;subagency=CEN></script>
 </head>


### PR DESCRIPTION
# Pull Request

## Description

Reverts GSA DAP script to load as a script instead of a `link` with a preconnect setting.

## Related Issue

N/A

## Changes Made

Change GSA DAP loading from `link` to `script` element

## Screenshots (if applicable)

Include screenshots or GIFs that demonstrate the changes, if relevant.

## Checklist

- [ ] I have read the CONTRIBUTING.md document.
- [X] My code follows the project's coding standards.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] All new and existing tests passed.
- [ ] I have updated the documentation accordingly.
- [X] The title of my pull request is a short description of the changes.
- [ ] My pull request is assigned to the appropriate milestone.

## Additional Notes

Reference: https://github.com/digital-analytics-program/gov-wide-code/blob/master/documentation/GSA%20DAP%204.1%20-%20Quick%20Guide.pdf
